### PR TITLE
Feature/save yaml

### DIFF
--- a/config/command_config.yaml
+++ b/config/command_config.yaml
@@ -1,10 +1,9 @@
----
 outputs:
   access_file: 'no'
   difference_csv: 'no'
   fixity:
-    check_fixity: 'no'
-    check_stream_fixity: 'no'
+    check_fixity: 'yes'
+    check_stream_fixity: 'yes'
     embed_stream_fixity: 'no'
     output_fixity: 'no'
     overwrite_stream_fixity: 'no'
@@ -14,7 +13,7 @@ tools:
     check_exiftool: 'yes'
     run_exiftool: 'no'
   ffprobe:
-    check_ffprobe: 'yes'
+    check_ffprobe: 'no'
     run_ffprobe: 'no'
   mediaconch:
     mediaconch_policy: JPC_AV_NTSC_MKV_2023-11-21.xml
@@ -23,15 +22,17 @@ tools:
     check_mediainfo: 'yes'
     run_mediainfo: 'no'
   qctools:
-    check_qctools: 'yes'
-    run_qctools: 'no'
+    check_qctools: 'no'
+    run_qctools: 'yes'
   qct-parse:
-    barsDetection: True
+    barsDetection: true
     contentFilter: silence
-    detectContent: True
-    evaluateBars: True
+    detectContent: true
+    evaluateBars: true
     profile: highTolerance
-    tagname: 
-      - [YMIN, lt, 100]
-    thumbExport: null
-    thumbExportDelay: null
+    tagname:
+## 'tagname' format:
+##  - [YMIN, lt, 100] 
+    - [YMIN, lt, 100]
+    thumbExport:
+    thumbExportDelay:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,8 +1,9 @@
 mediaconch_policy: JPC_AV_01709_mkv.xml
 filename_values:
-  Collection: JPC
-  MediaType: AV
-  ObjectID: \d{5}
+  Collection: '2012_79'
+  MediaType: '2'
+  ObjectID: \d{3}_\d{1}[a-zA-Z]
+  DigitalGeneration: PM
   FileExtension: mkv
 mediainfo_values:
   expected_general:
@@ -42,11 +43,11 @@ mediainfo_values:
     Bit depth: 24 bits
     Compression mode: Lossless
   expected_custom_fields:
-    Title: null
-    Encoded by: null
-    Description: null
-    Encoding settings: null
-    ORIGINAL MEDIA TYPE: null
+    Title:
+    Encoded by:
+    Description:
+    Encoding settings:
+    ORIGINAL MEDIA TYPE:
 exiftool_values:
   File Type: MKV
   File Type Extension: mkv
@@ -98,9 +99,17 @@ ffmpeg_values:
     format_name: matroska webm
     format_long_name: Matroska / WebM
     tags:
-      creation_time: null
-      ENCODER: null
-      TITLE: null
+      creation_time:
+      ENCODER:
+      TITLE:
+  ##  Re: ENCODER_SETTINGS 'device fields' below:
+  ##  Source VTR, TBC, Framesync, ADC, Capture Device, and Computer are required fields
+  ##  Subfields under these devices should be in this format:
+   #    Source VTR:
+   #    - model name
+   #    - serial number 
+   #    - video signal type (Composite, SDI, etc.) 
+   #    - audio connector type (XLR, RCA, etc.)
       ENCODER_SETTINGS:
         Source VTR:
         - SVO5800
@@ -128,9 +137,9 @@ ffmpeg_values:
         - OS 14.4
         - vrecord (2024.01.01)
         - ffmpeg
-      DESCRIPTION: null
-      ORIGINAL MEDIA TYPE: null
-      ENCODED_BY: null
+      DESCRIPTION:
+      ORIGINAL MEDIA TYPE:
+      ENCODED_BY:
 qct-parse:
   content:
     silence:
@@ -201,41 +210,41 @@ qct-parse:
       TOUT: 0.009
       VREP: 0.03
   fullTagList:
-    YMIN: null
-    YLOW: null
-    YAVG: null
-    YHIGH: null
-    YMAX: null
-    UMIN: null
-    ULOW: null
-    UAVG: null
-    UHIGH: null
-    UMAX: null
-    VMIN: null
-    VLOW: null
-    VAVG: null
-    VHIGH: null
-    VMAX: null
-    SATMIN: null
-    SATLOW: null
-    SATAVG: null
-    SATHIGH: null
-    SATMAX: null
-    HUEMED: null
-    HUEAVG: null
-    YDIF: null
-    UDIF: null
-    VDIF: null
-    TOUT: null
-    VREP: null
-    BRNG: null
-    mse_y: null
-    mse_u: null
-    mse_v: null
-    mse_avg: null
-    psnr_y: null
-    psnr_u: null
-    psnr_v: null
-    psnr_avg: null
-    Overall_Min_level: null
-    Overall_Max_level: null
+    YMIN:
+    YLOW:
+    YAVG:
+    YHIGH:
+    YMAX:
+    UMIN:
+    ULOW:
+    UAVG:
+    UHIGH:
+    UMAX:
+    VMIN:
+    VLOW:
+    VAVG:
+    VHIGH:
+    VMAX:
+    SATMIN:
+    SATLOW:
+    SATAVG:
+    SATHIGH:
+    SATMAX:
+    HUEMED:
+    HUEAVG:
+    YDIF:
+    UDIF:
+    VDIF:
+    TOUT:
+    VREP:
+    BRNG:
+    mse_y:
+    mse_u:
+    mse_v:
+    mse_avg:
+    psnr_y:
+    psnr_u:
+    psnr_v:
+    psnr_avg:
+    Overall_Min_level:
+    Overall_Max_level:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.1.1"
+version = "0.2.1"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
 dependencies = [
-    "PyYAML==6.0.1",
+    "ruamel.yaml==0.18.6",
     "colorlog==6.7.0",
     "art==6.1"
 ]

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from .utils.log_setup import logger
 from .utils.deps_setup import required_commands, check_external_dependency, check_py_version
 from .utils.find_config import config_path, command_config, yaml
-from .utils.yaml_profiles import apply_profile, update_config, profile_step1, profile_step2, JPC_AV_SVHS, bowser_filename, JPCAV_filename
+from .utils.yaml_profiles import *
 from .checks.fixity_check import check_fixity, output_fixity
 from .checks.filename_check import check_filenames
 from .checks.mediainfo_check import parse_mediainfo
@@ -164,6 +164,7 @@ def parse_arguments():
     parser.add_argument("--profile", choices=["step1", "step2"], help="Select processing profile (step1 or step2)")
     parser.add_argument("-sn","--signalflow", choices=["JPC_AV_SVHS"], help="Select signal flow config type (JPC_AV_SVHS)")
     parser.add_argument("-fn","--filename", choices=["jpc", "bowser"], help="Select file name config type (jpc or bowser)")
+    parser.add_argument("-sp","--saveprofile", action="store_true", help="Flag to write current command_config settings to new yaml file, for re-use or reference.")
     parser.add_argument("-d", "--directory", action="store_true", help="Flag to indicate input is a directory")
     parser.add_argument("-f", "--file", action="store_true", help="Flag to indicate input is a video file")
 
@@ -214,7 +215,9 @@ def parse_arguments():
 
     dry_run_only = args.dryrun
 
-    return source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only
+    save_profile = args.saveprofile
+
+    return source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only, save_profile
 
 def main():
     '''
@@ -227,7 +230,7 @@ def main():
     print(f'\n{avspex_icon}\n\n')
     time.sleep(1)
     
-    source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only = parse_arguments()
+    source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only, save_profile = parse_arguments()
 
     check_py_version()
     
@@ -244,6 +247,11 @@ def main():
 
     if fn_config_changes:
         update_config(config_path, 'filename_values', fn_config_changes)
+
+    if save_profile:
+        config_dir = command_config.config_dir
+        user_profile_config = os.path.join(config_dir, f"command_profile_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.yaml")
+        save_profile_to_file(command_config, user_profile_config)
 
     if dry_run_only:
         logger.critical(f"Dry run selected. Exiting now.\n\n")

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -6,7 +6,8 @@ import subprocess
 import sys
 import re
 import logging
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
 import csv
 import shutil
 import argparse

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 from .utils.log_setup import logger
 from .utils.deps_setup import required_commands, check_external_dependency, check_py_version
-from .utils.find_config import config_path, command_config
+from .utils.find_config import config_path, command_config, yaml
 from .utils.yaml_profiles import apply_profile, update_config, profile_step1, profile_step2, JPC_AV_SVHS, bowser_filename, JPCAV_filename
 from .checks.fixity_check import check_fixity, output_fixity
 from .checks.filename_check import check_filenames

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -164,7 +164,7 @@ def parse_arguments():
     parser.add_argument("--profile", choices=["step1", "step2"], help="Select processing profile (step1 or step2)")
     parser.add_argument("-sn","--signalflow", choices=["JPC_AV_SVHS"], help="Select signal flow config type (JPC_AV_SVHS)")
     parser.add_argument("-fn","--filename", choices=["jpc", "bowser"], help="Select file name config type (jpc or bowser)")
-    parser.add_argument("-sp","--saveprofile", action="store_true", help="Flag to write current command_config settings to new yaml file, for re-use or reference.")
+    parser.add_argument("-sp","--saveprofile", choices=["config", "command"], help="Flag to write current config.yaml or command_config.yaml settings to new a yaml file, for re-use or reference. Select config or command: --saveprofile command")
     parser.add_argument("-d", "--directory", action="store_true", help="Flag to indicate input is a directory")
     parser.add_argument("-f", "--file", action="store_true", help="Flag to indicate input is a video file")
 
@@ -215,9 +215,19 @@ def parse_arguments():
 
     dry_run_only = args.dryrun
 
-    save_profile = args.saveprofile
+    save_config_type = None
+    user_profile_config = None
+    if args.saveprofile:
+        if args.saveprofile == 'config':
+            save_config_type = config_path 
+            config_dir = config_path.config_dir
+            user_profile_config = os.path.join(config_dir, f"config_profile_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.yaml")
+        elif args.saveprofile == 'command':
+            save_config_type = command_config
+            config_dir = command_config.config_dir
+            user_profile_config = os.path.join(config_dir, f"command_profile_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.yaml")
 
-    return source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only, save_profile
+    return source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only, save_config_type, user_profile_config
 
 def main():
     '''
@@ -230,7 +240,7 @@ def main():
     print(f'\n{avspex_icon}\n\n')
     time.sleep(1)
     
-    source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only, save_profile = parse_arguments()
+    source_directories, selected_profile, sn_config_changes, fn_config_changes, dry_run_only, save_config_type, user_profile_config = parse_arguments()
 
     check_py_version()
     
@@ -248,10 +258,8 @@ def main():
     if fn_config_changes:
         update_config(config_path, 'filename_values', fn_config_changes)
 
-    if save_profile:
-        config_dir = command_config.config_dir
-        user_profile_config = os.path.join(config_dir, f"command_profile_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.yaml")
-        save_profile_to_file(command_config, user_profile_config)
+    if save_config_type:
+        save_profile_to_file(save_config_type, user_profile_config)
 
     if dry_run_only:
         logger.critical(f"Dry run selected. Exiting now.\n\n")

--- a/src/AV_Spex/checks/ffprobe_check.py
+++ b/src/AV_Spex/checks/ffprobe_check.py
@@ -58,7 +58,6 @@ def parse_ffprobe(file_path):
             # if variable "actual_value" does not match "expected value" defined in first line as the values from the dictionary expected_video, then
                 ffprobe_differences.append(f"Metadata field {expected_key} has a value of: {actual_value}\nThe expected value is: {expected_value}")
                 # append this string to the list "ffprobe_differences"
-
     
     for expected_key, expected_value in expected_format_values.items():
     # defines variables "expected_key" and "expected_value" to the dictionary "expected_audio"

--- a/src/AV_Spex/checks/qct_parse.py
+++ b/src/AV_Spex/checks/qct_parse.py
@@ -17,7 +17,6 @@ import subprocess
 import math				
 import sys			
 import re
-import yaml
 import operator
 from statistics import median
 from ..utils.log_setup import logger

--- a/src/AV_Spex/utils/find_config.py
+++ b/src/AV_Spex/utils/find_config.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
-import yaml
-import logging
+from ruamel.yaml import YAML
 from ..utils.log_setup import logger
+
+yaml = YAML()
+yaml.preserve_quotes = True
 
 class ConfigPath:
     def __init__(self):
@@ -16,10 +15,10 @@ class ConfigPath:
         self.config_dir = os.path.join(self.root_dir, 'config')
         self.config_yml = os.path.join(self.config_dir, 'config.yaml')
 
-        #logger.debug(f'config.yaml sourced from {self.config_yml}')
+        # logger.debug(f'config.yaml sourced from {self.config_yml}')
         
         with open(self.config_yml) as f:
-            self.config_dict = yaml.safe_load(f)
+            self.config_dict = yaml.load(f)
 
 class CommandConfig:
     def __init__(self):
@@ -31,13 +30,13 @@ class CommandConfig:
         self.config_dir = os.path.join(self.root_dir, 'config')
         self.command_yml = os.path.join(self.config_dir, 'command_config.yaml')
 
-        #logger.debug(f'command_config.yaml sourced from {self.command_yml}')
+        # logger.debug(f'command_config.yaml sourced from {self.command_yml}')
         
         with open(self.command_yml) as f:
-            self.command_dict = yaml.safe_load(f)
+            self.command_dict = yaml.load(f)
 
-# Create an instance of the ConfigVariables class
+# Create an instance of the ConfigPath class
 config_path = ConfigPath()
 
-# Create an instance of the ConfigVariables class
+# Create an instance of the CommandConfig class
 command_config = CommandConfig()

--- a/src/AV_Spex/utils/yaml_profiles.py
+++ b/src/AV_Spex/utils/yaml_profiles.py
@@ -56,6 +56,22 @@ def update_config(config_path, nested_key, value_dict):
             yaml.dump(config_dict, y)
             logger.info(f'config.yaml updated to match profile {last_key}')
 
+# Function to save the current state of the command_config.yaml to a dictionary (profile)
+def save_current_profile(command_config):
+    with open(command_config.command_yml, 'r') as f:
+        current_profile = yaml.load(f)
+    return current_profile
+
+# Function to save the current profile to a new YAML file
+def save_profile_to_file(command_config, new_file_path):
+    current_profile = save_current_profile(command_config)
+    if current_profile:
+        with open(new_file_path, 'w') as f:
+            yaml.dump(current_profile, f)
+        logger.info(f'Profile saved to {new_file_path}')
+    else:
+        logger.critical(f'Unable to save command profile!')
+
 profile_step1 = {
     "tools": {
         "qctools": {

--- a/src/AV_Spex/utils/yaml_profiles.py
+++ b/src/AV_Spex/utils/yaml_profiles.py
@@ -3,14 +3,11 @@ import sys
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 import argparse
-from ..utils.find_config import config_path, command_config
+from ..utils.find_config import config_path, command_config, yaml
 from ..utils.log_setup import logger
 
 # Function to apply profile changes
 def apply_profile(command_config, selected_profile):
-    yaml = YAML()
-    yaml.preserve_quotes = True
-
     with open(command_config.command_yml, "r") as f:
         command_dict = yaml.load(f)
 
@@ -30,9 +27,6 @@ def apply_profile(command_config, selected_profile):
     logger.info(f'command_config.yaml updated to match selected tool profile')
 
 def update_config(config_path, nested_key, value_dict):
-    yaml = YAML()
-    yaml.preserve_quotes = True
-
     with open(config_path.config_yml, "r") as f:
         config_dict = yaml.load(f)
     

--- a/src/AV_Spex/utils/yaml_profiles.py
+++ b/src/AV_Spex/utils/yaml_profiles.py
@@ -57,14 +57,18 @@ def update_config(config_path, nested_key, value_dict):
             logger.info(f'config.yaml updated to match profile {last_key}')
 
 # Function to save the current state of the command_config.yaml to a dictionary (profile)
-def save_current_profile(command_config):
-    with open(command_config.command_yml, 'r') as f:
-        current_profile = yaml.load(f)
+def save_current_profile(config):
+    if config == command_config:
+        with open(config.command_yml, 'r') as f:
+            current_profile = yaml.load(f)
+    else:
+        with open(config.config_yml, 'r') as f:
+            current_profile = yaml.load(f)
     return current_profile
 
 # Function to save the current profile to a new YAML file
-def save_profile_to_file(command_config, new_file_path):
-    current_profile = save_current_profile(command_config)
+def save_profile_to_file(config, new_file_path):
+    current_profile = save_current_profile(config)
     if current_profile:
         with open(new_file_path, 'w') as f:
             yaml.dump(current_profile, f)


### PR DESCRIPTION
## Description
New feature to save the config.yaml or command_config.yaml with the -sp/--saveprofile flag

`av-spex --saveprofile config` or `av-spex --saveprofile command` to save the current config.yaml or command_config.yaml (respectively) as a new yaml file. New yaml file will be named w/ the date and time as a suffix.

Comments written to the yaml will now be preserved even if fields are written programmatically. 

This pull request introduces new dependencies required for the latest features. The `pyproject.toml` file has been updated accordingly.

## Dependencies Added
    "ruamel.yaml==0.18.6"

PyYaml doesn't offer as much flexibility when writing to a yaml file so we're switching to ruamel.yaml
    
  ## Actions Required
After pulling the latest main branch, please run the following command to install the new dependencies:

```bash
python -m pip install -e .