### PR TITLE
Feature/new flags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.4.4"
+version = "0.4.5"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -212,16 +212,16 @@ The scripts will confirm that the digital files conform to predetermined specifi
     parser.add_argument('--version', action='version', version=f'%(prog)s {version_string}')
     parser.add_argument("paths", nargs='*', help="Path to the input -f: video file(s) or -d: directory(ies)")
     parser.add_argument("-dr","--dryrun", action="store_true", help="Flag to run av-spex w/out outputs or checks. Use to change config profiles w/out processing video.")
-    parser.add_argument("--profile", choices=["step1", "step2", "off"], help="Select processing profile (step1 or step2), or turn all checks off with 'off'")
+    parser.add_argument("--profile", choices=["step1", "step2", "off"], help="Select processing profile ('step1' or 'step2'), or turn all checks off with 'off'")
     parser.add_argument("-t", "--tool", choices=["exiftool", "ffprobe", "mediaconch", "mediainfo", "mediatrace", "qctools"], 
                         action='append',  # Allow multiple tool selections
                         help="Select individual tools to enable - turns all other tools off") 
     parser.add_argument("--on", choices=["exiftool", "ffprobe", "mediaconch", "mediainfo", "mediatrace", "qctools"], 
                         action='append',  
-                        help="Select specific tools to enable") 
+                        help="Select specific tools to turn on") 
     parser.add_argument("--off", choices=["exiftool", "ffprobe", "mediaconch", "mediainfo", "mediatrace", "qctools"], 
                         action='append',  
-                        help="Select specific tools to enable") 
+                        help="Select specific tools to turn off") 
     parser.add_argument("-sn","--signalflow", choices=["JPC_AV_SVHS", "BVH3100"], help="Select signal flow config type (JPC_AV_SVHS or BVH3100)")
     parser.add_argument("-fn","--filename", choices=["jpc", "bowser"], help="Select file name config type (jpc or bowser)")
     parser.add_argument("-sp","--saveprofile", choices=["config", "command"], help="Flag to write current config.yaml or command_config.yaml settings to new a yaml file, for re-use or reference. Select config or command: --saveprofile command")

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -215,15 +215,19 @@ The scripts will confirm that the digital files conform to predetermined specifi
     parser.add_argument("--profile", choices=["step1", "step2", "off"], help="Select processing profile (step1 or step2), or turn all checks off with 'off'")
     parser.add_argument("-t", "--tool", choices=["exiftool", "ffprobe", "mediaconch", "mediainfo", "mediatrace", "qctools"], 
                         action='append',  # Allow multiple tool selections
+                        help="Select individual tools to enable - turns all other tools off") 
+    parser.add_argument("--on", choices=["exiftool", "ffprobe", "mediaconch", "mediainfo", "mediatrace", "qctools"], 
+                        action='append',  
+                        help="Select specific tools to enable") 
+    parser.add_argument("--off", choices=["exiftool", "ffprobe", "mediaconch", "mediainfo", "mediatrace", "qctools"], 
+                        action='append',  
                         help="Select specific tools to enable") 
     parser.add_argument("-sn","--signalflow", choices=["JPC_AV_SVHS", "BVH3100"], help="Select signal flow config type (JPC_AV_SVHS or BVH3100)")
     parser.add_argument("-fn","--filename", choices=["jpc", "bowser"], help="Select file name config type (jpc or bowser)")
     parser.add_argument("-sp","--saveprofile", choices=["config", "command"], help="Flag to write current config.yaml or command_config.yaml settings to new a yaml file, for re-use or reference. Select config or command: --saveprofile command")
     parser.add_argument("-d", "--directory", action="store_true", help="Flag to indicate input is a directory")
     parser.add_argument("-f", "--file", action="store_true", help="Flag to indicate input is a video file")
-    # make "turn on" which toggles checks on and leaves everything else the same
     # make "turn off" which toggles checks on and leaves everything else the same
-    # make "checks" flag which will turn everything off except stated checks, takes multiple inputs.
 
     args = parser.parse_args()
 
@@ -261,7 +265,11 @@ The scripts will confirm that the digital files conform to predetermined specifi
             selected_profile = profile_allOff
     
     # Handle the selected tools
-    tool_names = args.tool  # Get the list of selected tools
+    tool_names = args.tool  
+
+    tools_on_names = args.on
+
+    tools_off_names = args.off
 
     sn_config_changes = None
     if args.signalflow:
@@ -291,7 +299,7 @@ The scripts will confirm that the digital files conform to predetermined specifi
             config_dir = command_config.config_dir
             user_profile_config = os.path.join(config_dir, f"command_profile_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.yaml")
 
-    return source_directories, selected_profile, tool_names, sn_config_changes, fn_config_changes, dry_run_only, save_config_type, user_profile_config
+    return source_directories, selected_profile, tool_names, sn_config_changes, fn_config_changes, dry_run_only, save_config_type, user_profile_config, tools_on_names, tools_off_names
 
 def main():
     '''
@@ -304,7 +312,7 @@ def main():
     print(f'{avspex_icon}\n')
     #time.sleep(1)
     
-    source_directories, selected_profile, tool_names, sn_config_changes, fn_config_changes, dry_run_only, save_config_type, user_profile_config = parse_arguments()
+    source_directories, selected_profile, tool_names, sn_config_changes, fn_config_changes, dry_run_only, save_config_type, user_profile_config, tools_on_names, tools_off_names = parse_arguments()
 
     check_py_version()
     
@@ -320,8 +328,17 @@ def main():
     if tool_names and selected_profile:
         logger.critical(f"Both profile and individual tools selected! Cannot use '-t'/-tool' with '--profile'. Exiting...")
         sys.exit(1)
+    elif tool_names and tools_on_names:
+        logger.critical(f"Both 'on' option and individual tools selected! Cannot use '-t'/-tool' with '--on'. Exiting...")
+        sys.exit(1)
     elif tool_names:
         apply_by_name(command_config, tool_names)
+
+    if tools_on_names:
+        toggle_on(command_config, tools_on_names)
+
+    if tools_off_names:
+        toggle_off(command_config, tools_off_names)
 
     if sn_config_changes:
         update_config(config_path, 'ffmpeg_values.format.tags.ENCODER_SETTINGS', sn_config_changes)

--- a/src/AV_Spex/checks/embed_fixity.py
+++ b/src/AV_Spex/checks/embed_fixity.py
@@ -130,9 +130,9 @@ def write_tags_to_mkv(mkv_file, temp_xml_file):
     if stdout:
         # Modify the output as needed
         modified_output = stdout.decode('utf-8').replace('Done.', '')
-        logger.info(f'Running mkvpropedit:{modified_output}')  # Or do something else with the modified output
+        logger.info(f'Running mkvpropedit:\n{modified_output}')  # Or do something else with the modified output
     if stderr:
-        logger.critical(f"Running mkvpropedit:{stderr.decode('utf-8')}")  # Print any errors if they occur
+        logger.critical(f"Running mkvpropedit:\n{stderr.decode('utf-8')}")  # Print any errors if they occur
 
 def extract_hashes(xml_tags):
     video_hash = None
@@ -174,6 +174,7 @@ def embed_fixity(video_path):
     # Make md5 of video/audio stream
     logger.debug(f'Generating video and audio stream hashes. This may take a moment...')
     video_hash, audio_hash = make_stream_hash(video_path)
+    logger.debug('') # add space after stream hash output
     logger.info(f'Video hash = {video_hash}\nAudio hash = {audio_hash}\n')
 
     # Extract existing tags

--- a/src/AV_Spex/utils/yaml_profiles.py
+++ b/src/AV_Spex/utils/yaml_profiles.py
@@ -42,6 +42,34 @@ def apply_by_name(command_config, tool_names):
 
     apply_profile(command_config, tool_profile)  # Apply the selective changes
 
+def toggle_on(command_config, tool_names):
+
+    tool_profile = {"tools": {}}  # Initialize the tool_profile dictionary
+
+    for tool in tool_names:
+        # Check if the tool exists in the command_config
+        if tool in command_config.command_dict["tools"]:
+            tool_profile["tools"][tool] = {
+                subfield: "yes" for subfield in command_config.command_dict["tools"][tool]
+            }
+            logger.debug(f"{tool} set to 'on'")
+
+    apply_profile(command_config, tool_profile)  # Apply the selective changes
+
+def toggle_off(command_config, tool_names):
+
+    tool_profile = {"tools": {}}  # Initialize the tool_profile dictionary
+
+    for tool in tool_names:
+        # Check if the tool exists in the command_config
+        if tool in command_config.command_dict["tools"]:
+            tool_profile["tools"][tool] = {
+                subfield: "no" for subfield in command_config.command_dict["tools"][tool]
+            }
+            logger.debug(f"{tool} set to 'off'")
+
+    apply_profile(command_config, tool_profile)  # Apply the selective changes
+
 def update_config(config_path, nested_key, value_dict):
     with open(config_path.config_yml, "r") as f:
         config_dict = yaml.load(f)

--- a/src/AV_Spex/utils/yaml_profiles.py
+++ b/src/AV_Spex/utils/yaml_profiles.py
@@ -11,20 +11,36 @@ def apply_profile(command_config, selected_profile):
     with open(command_config.command_yml, "r") as f:
         command_dict = yaml.load(f)
 
-    for output, output_settings in selected_profile["outputs"].items():
-        if output in command_dict["outputs"]:
-            if isinstance(output_settings, dict):
-                command_dict["outputs"][output].update(output_settings)
-            else:
-                command_dict["outputs"][output] = output_settings
+    if 'outputs' in selected_profile:
+        for output, output_settings in selected_profile["outputs"].items():
+            if output in command_dict["outputs"]:
+                if isinstance(output_settings, dict):
+                    command_dict["outputs"][output].update(output_settings)
+                else:
+                    command_dict["outputs"][output] = output_settings
 
-    for tool, updates in selected_profile["tools"].items():
-        if tool in command_dict["tools"]:
-            command_dict["tools"][tool].update(updates)
+    if 'tools' in selected_profile:
+        for tool, updates in selected_profile["tools"].items():
+            if tool in command_dict["tools"]:
+                command_dict["tools"][tool].update(updates)
 
     with open(command_config.command_yml, "w") as f:
         yaml.dump(command_dict, f)
-    logger.info(f'command_config.yaml updated to match selected tool profile\n')
+
+def apply_by_name(command_config, tool_names):
+    apply_profile(command_config, profile_allOff)  # Turn everything off initially
+
+    tool_profile = {"tools": {}}  # Initialize the tool_profile dictionary
+
+    for tool in tool_names:
+        # Check if the tool exists in the command_config
+        if tool in command_config.command_dict["tools"]:
+            tool_profile["tools"][tool] = {
+                subfield: "yes" for subfield in command_config.command_dict["tools"][tool]
+            }
+            logger.debug(f"{tool} set to 'on'")
+
+    apply_profile(command_config, tool_profile)  # Apply the selective changes
 
 def update_config(config_path, nested_key, value_dict):
     with open(config_path.config_yml, "r") as f:
@@ -155,6 +171,51 @@ profile_step2 = {
             "check_fixity": 'yes',
             "embed_stream_fixity": 'no',
             "check_stream_fixity": 'yes'
+        }
+    }
+}
+
+profile_allOff = {
+    "tools": {
+        "exiftool": {
+            "check_exiftool": 'no',
+            "run_exiftool": 'no'
+        },
+        "ffprobe": {
+            "check_ffprobe": 'no',
+            "run_ffprobe": 'no'
+        },
+        "mediaconch": {
+            "run_mediaconch": 'no'
+        },
+        "mediatrace": {
+            "check_mediatrace": 'no',
+            "run_mediatrace": 'no'
+        },
+        "mediainfo": {
+            "check_mediainfo": 'no',
+            "run_mediainfo": 'no'
+        },
+        "qctools": {
+            "run_qctools": 'no',
+            "check_qctools": 'no'
+        },
+        "qct-parse": {
+            "barsDetection": None,
+            "evaluateBars": None,
+            "contentFilter": None,
+            "profile": None,
+            "thumbExport": None
+        }
+    },
+    "outputs": {
+        "report": 'no',
+        "access_file": 'no',
+        "fixity": {
+            "output_fixity": 'no',
+            "check_fixity": 'no',
+            "embed_stream_fixity": 'no',
+            "check_stream_fixity": 'no'
         }
     }
 }


### PR DESCRIPTION
Adding flags to disable/enable specific tools. 

The -t or --tool flag turns the specific indicated tool or tools on and everything else on. 
For example:
`av-spex -t mediainfo -t exiftool`
Would only run mediainfo and exiftool, all other checks would be turned off. The command creates sidecars and check those sidecars against config policy.

The --on and --off flags toggle a specific tools on/off. All other command_config settings remain unchanged.
For example:
`av-spex --off exiftool`
Would turn run_exiftool and check_exiftool in the command_config.yaml to 'no' and leave the rest of the yaml the unchanged.