### PR TITLE
Feature/move qctp checkbox

### DIFF
--- a/src/AV_Spex/config/checks_config.json
+++ b/src/AV_Spex/config/checks_config.json
@@ -33,10 +33,10 @@
       "run_tool": "yes"
     },
     "qctools": {
-      "check_tool": "no",
       "run_tool": "no"
     },
     "qct_parse": {
+      "run_tool": "yes",
       "barsDetection": true,
       "evaluateBars": true,
       "contentFilter": [],

--- a/src/AV_Spex/processing/processing_mgmt.py
+++ b/src/AV_Spex/processing/processing_mgmt.py
@@ -282,7 +282,7 @@ def process_qctools_output(video_path, source_directory, destination_directory, 
         results['qctools_output_path'] = qctools_output_path
 
     # Check QCTools output if configured
-    if checks_config.tools.qctools.check_tool == 'yes':
+    if checks_config.tools.qct_parse.run_tool == 'yes':
         # Ensure report directory exists
         if not report_directory:
             report_directory = dir_setup.make_report_dir(source_directory, video_id)

--- a/src/AV_Spex/utils/edit_config.py
+++ b/src/AV_Spex/utils/edit_config.py
@@ -245,6 +245,12 @@ profile_step1 = {
         "mediatrace": {
             "check_tool": "yes",
             "run_tool": "yes"
+        },
+        "qctools": {
+            "run_tool": "no"
+        },
+        "qct_parse": {
+            "run_tool": "no"
         }
     },
     "outputs": {
@@ -333,10 +339,10 @@ profile_allOff = {
             "run_tool": "no"
         },
         "qctools": {
-            "check_tool": "no",
             "run_tool": "no"
         },
         "qct_parse": {
+            "run_tool": "no",
             "barsDetection": False,
             "evaluateBars": False,
             "contentFilter": [],

--- a/src/AV_Spex/utils/edit_config.py
+++ b/src/AV_Spex/utils/edit_config.py
@@ -224,7 +224,6 @@ def toggle_off(tool_names: List[str]):
 profile_step1 = {
     "tools": {
         "qctools": {
-            "check_tool": "no",
             "run_tool": "no"   
         },
         "exiftool": {
@@ -285,10 +284,10 @@ profile_step2 = {
             "run_tool": "no"
         },
         "qctools": {
-            "check_tool": "yes",
             "run_tool": "yes"
         },
         "qct_parse": {
+            "run_tool": "yes",
             "barsDetection": True,
             "evaluateBars": True,
             "contentFilter": [],

--- a/src/AV_Spex/utils/gui_setup.py
+++ b/src/AV_Spex/utils/gui_setup.py
@@ -199,9 +199,13 @@ class ConfigWindow(QWidget):
             tool_layout = QVBoxLayout()
             check_cb = QCheckBox("Check Tool")
             run_cb = QCheckBox("Run Tool")
-            self.tool_widgets[tool] = {'check': check_cb, 'run': run_cb}
-            tool_layout.addWidget(check_cb)
-            tool_layout.addWidget(run_cb)
+            if tool == 'qctools':
+                self.tool_widgets[tool] = {'run': run_cb}
+                tool_layout.addWidget(run_cb)
+            else:
+                self.tool_widgets[tool] = {'check': check_cb, 'run': run_cb}
+                tool_layout.addWidget(check_cb)
+                tool_layout.addWidget(run_cb)
             tool_group.setLayout(tool_layout)
             tools_layout.addWidget(tool_group)
         
@@ -243,7 +247,8 @@ class ConfigWindow(QWidget):
         # QCT Parse
         qct_group = QGroupBox("qct-parse")
         qct_layout = QVBoxLayout()
-        
+
+        self.run_qctparse_cb = QCheckBox("Run Tool")
         self.bars_detection_cb = QCheckBox("barsDetection")
         self.evaluate_bars_cb = QCheckBox("evaluateBars")
         self.thumb_export_cb = QCheckBox("thumbExport")
@@ -265,6 +270,7 @@ class ConfigWindow(QWidget):
         self.tagname_input = QLineEdit()
         self.tagname_input.setPlaceholderText("None")
         
+        qct_layout.addWidget(self.run_qctparse_cb)
         qct_layout.addWidget(self.bars_detection_cb)
         qct_layout.addWidget(self.evaluate_bars_cb)
         qct_layout.addWidget(self.thumb_export_cb)
@@ -318,12 +324,17 @@ class ConfigWindow(QWidget):
         
         # Tools section
         for tool, widgets in self.tool_widgets.items():
-            widgets['check'].stateChanged.connect(
-                lambda state, t=tool: self.on_checkbox_changed(state, ['tools', t, 'check_tool'])
-            )
-            widgets['run'].stateChanged.connect(
+            if tool == 'qctools':
+                widgets['run'].stateChanged.connect(
                 lambda state, t=tool: self.on_checkbox_changed(state, ['tools', t, 'run_tool'])
             )
+            else:
+                widgets['check'].stateChanged.connect(
+                    lambda state, t=tool: self.on_checkbox_changed(state, ['tools', t, 'check_tool'])
+                )
+                widgets['run'].stateChanged.connect(
+                    lambda state, t=tool: self.on_checkbox_changed(state, ['tools', t, 'run_tool'])
+                )
         
         # MediaConch
         mediaconch = self.checks_config.tools.mediaconch
@@ -336,6 +347,9 @@ class ConfigWindow(QWidget):
         self.import_policy_btn.clicked.connect(self.open_policy_file_dialog)
                     
         # QCT Parse
+        self.run_qctparse_cb.stateChanged.connect(
+            lambda state: self.on_boolean_changed(state, ['tools', 'qct_parse', 'run_tool'])
+        )
         self.bars_detection_cb.stateChanged.connect(
             lambda state: self.on_boolean_changed(state, ['tools', 'qct_parse', 'barsDetection'])
         )
@@ -375,8 +389,11 @@ class ConfigWindow(QWidget):
         # Tools
         for tool, widgets in self.tool_widgets.items():
             tool_config = getattr(self.checks_config.tools, tool)
-            widgets['check'].setChecked(tool_config.check_tool.lower() == 'yes')
-            widgets['run'].setChecked(tool_config.run_tool.lower() == 'yes')
+            if tool == 'qctools':
+                widgets['run'].setChecked(tool_config.run_tool.lower() == 'yes')
+            else:
+                widgets['check'].setChecked(tool_config.check_tool.lower() == 'yes')
+                widgets['run'].setChecked(tool_config.run_tool.lower() == 'yes')
         
         # MediaConch
         mediaconch = self.checks_config.tools.mediaconch

--- a/src/AV_Spex/utils/gui_setup.py
+++ b/src/AV_Spex/utils/gui_setup.py
@@ -348,7 +348,7 @@ class ConfigWindow(QWidget):
                     
         # QCT Parse
         self.run_qctparse_cb.stateChanged.connect(
-            lambda state: self.on_boolean_changed(state, ['tools', 'qct_parse', 'run_tool'])
+            lambda state: self.on_checkbox_changed(state, ['tools', 'qct_parse', 'run_tool'])
         )
         self.bars_detection_cb.stateChanged.connect(
             lambda state: self.on_boolean_changed(state, ['tools', 'qct_parse', 'barsDetection'])
@@ -417,6 +417,7 @@ class ConfigWindow(QWidget):
         
         # QCT Parse
         qct = self.checks_config.tools.qct_parse
+        self.run_qctparse_cb.setChecked(qct.run_tool.lower() == 'yes')
         self.bars_detection_cb.setChecked(qct.barsDetection)
         self.evaluate_bars_cb.setChecked(qct.evaluateBars)
         self.thumb_export_cb.setChecked(qct.thumbExport)

--- a/src/AV_Spex/utils/setup_config.py
+++ b/src/AV_Spex/utils/setup_config.py
@@ -311,12 +311,17 @@ class BasicToolConfig:
     run_tool: str
 
 @dataclass
+class QCToolsConfig:
+    run_tool: str
+
+@dataclass
 class MediaConchConfig:
     mediaconch_policy: str
     run_mediaconch: str
 
 @dataclass
 class QCTParseToolConfig:
+    run_tool: str
     barsDetection: bool
     evaluateBars: bool
     contentFilter: List[str]
@@ -331,7 +336,7 @@ class ToolsConfig:
     mediaconch: MediaConchConfig
     mediainfo: BasicToolConfig
     mediatrace: BasicToolConfig
-    qctools: BasicToolConfig
+    qctools: QCToolsConfig
     qct_parse: QCTParseToolConfig
 
 @dataclass


### PR DESCRIPTION
The check_qctools option in Checks Config (and GUI checkbox) used to run qct-parse, which is confusing. Now qct-parse used the Run Tool option like the other tools, and the QCTools has no "check tool" option