### PR TITLE
Pyinstaller/last used temp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,17 @@ av-spex = "AV_Spex.av_spex_the_file:main_cli"
 av-spex-gui = "AV_Spex.av_spex_the_file:main_gui"
 
 [tool.setuptools.packages.find]
-where = ["src"]  # list of folders that contain the packages (["."] by default)
-include = ["AV_Spex*"]  # package names should match these glob patterns (["*"] by default)
-exclude = ["config", "logs", "tests"]  # exclude packages matching these glob patterns (empty by default)
-namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+where = ["src"]
+include = ["AV_Spex*"]
+exclude = ["tests"]
+namespaces = false
+
+[tool.setuptools.package-data]
+"AV_Spex" = [
+    "config/*.json",
+    "config/mediaconch_policies/*.xml",
+    "logo_image_files/*.png"
+]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.6.3"
+version = "0.6.4"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -17,7 +17,6 @@ classifiers = [
 ]
 dependencies = [
     "appdirs==1.4.4",
-    "ruamel.yaml==0.18.6",
     "colorlog==6.7.0",
     "art==6.1",
     "lxml==5.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.6.2"
+version = "0.6.3"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/__init__.py
+++ b/src/AV_Spex/__init__.py
@@ -1,0 +1,2 @@
+# src/AV_Spex/__init__.py
+__version__ = "0.6.2"  

--- a/src/AV_Spex/__init__.py
+++ b/src/AV_Spex/__init__.py
@@ -1,2 +1,2 @@
 # src/AV_Spex/__init__.py
-__version__ = "0.6.2"  
+__version__ = "0.6.3"

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -97,18 +97,9 @@ SIGNAL_FLOW_CONFIGS = {
 
 
 def parse_arguments():
-    # Get the version from pyproject.toml
-    if getattr(sys, 'frozen', False):
-        # If running as bundled executable
-        base_path = sys._MEIPASS
-        project_path = base_path  # Set project_path for frozen app
-    else:
-        # If running from source
-        project_path = os.path.dirname(os.path.dirname(config_mgr._bundle_dir))
-        
-    pyproject_path = os.path.join(project_path, 'pyproject.toml')
-    with open(pyproject_path, 'r') as f:
-        version_string = toml.load(f)['project']['version']
+    # Get the version from __init__
+    from AV_Spex import __version__
+    version_string = __version__
 
     parser = argparse.ArgumentParser(
         description=f"""\

--- a/src/AV_Spex/checks/__init__.py
+++ b/src/AV_Spex/checks/__init__.py
@@ -1,0 +1,10 @@
+# src/AV_Spex/checks/__init__.py
+from . import embed_fixity
+from . import exiftool_check
+from . import ffprobe_check
+from . import fixity_check
+from . import make_access
+from . import mediaconch_check
+from . import mediainfo_check
+from . import mediatrace_check
+from . import qct_parse


### PR DESCRIPTION
Correctly locating "last used" config whether run from pip install, homebrew or app. 
Previous test release "0.6.3" is compatible with this homebrew formula: https://github.com/eddycolloton/homebrew-av-spex