### PR TITLE
Feature/smarter access file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.9.7.6"
+version = "0.9.7.7"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/checks/make_access.py
+++ b/src/AV_Spex/checks/make_access.py
@@ -18,22 +18,31 @@ def get_duration(video_path):
     return duration
 
 
-def make_access_file(video_path, output_path, check_cancelled=None, signals=None):
-    """Create access file using ffmpeg."""
+def make_access_file(video_path, output_path, check_cancelled=None, signals=None, start_time=None):
+    """Create access file using ffmpeg.
+
+    If start_time (seconds) is provided and > 0, the input is seeked past that
+    point so head content (e.g. color bars detected by qct-parse) is excluded
+    from the access copy.
+    """
 
     logger.debug(f'Running ffmpeg on {os.path.basename(video_path)} to create access copy {os.path.basename(output_path)}\n')
 
     duration_str = get_duration(video_path)
 
-    ffmpeg_command = [
-        'ffmpeg',
-        '-n', '-vsync', '0',
-        '-hide_banner', '-progress', 'pipe:1', '-nostats', '-loglevel', 'error',
+    ffmpeg_command = ['ffmpeg', '-n', '-vsync', '0',
+        '-hide_banner', '-progress', 'pipe:1', '-nostats', '-loglevel', 'error']
+
+    if start_time and start_time > 0:
+        logger.info(f'Trimming first {start_time:.2f}s from access copy (color bars detected by qct-parse)\n')
+        ffmpeg_command.extend(['-ss', f'{start_time:.3f}'])
+
+    ffmpeg_command.extend([
         '-i', video_path,
-        '-movflags', 'faststart', '-map', '0:v:0', '-map', '0:a?', '-c:v', 'libx264', 
-        '-vf', 'yadif=1,format=yuv420p', '-crf', '18', '-preset', 'fast', '-maxrate', '1000k', '-bufsize', '1835k', 
+        '-movflags', 'faststart', '-map', '0:v:0', '-map', '0:a?', '-c:v', 'libx264',
+        '-vf', 'yadif=1,format=yuv420p', '-crf', '18', '-preset', 'fast', '-maxrate', '1000k', '-bufsize', '1835k',
         '-c:a', 'aac', '-strict', '-2', '-b:a', '192k', '-f', 'mp4', output_path
-    ]
+    ])
 
     try:
         ffmpeg_process = subprocess.Popen(ffmpeg_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
@@ -44,6 +53,8 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
             duration_prefix = 'out_time_ms='
             # define prefix of ffmpeg microsecond progress output
             duration = float(duration_str)
+            if start_time and start_time > 0:
+                duration = max(0.001, duration - start_time)
             # Convert string integer
             duration_ms = (duration * 1000000)
             # Calculate the total duration in microseconds
@@ -68,22 +79,26 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
     print("\n")
 
 
-def process_access_file(video_path, source_directory, video_id, check_cancelled=None, signals=None):
+def process_access_file(video_path, source_directory, video_id, check_cancelled=None, signals=None, color_bars_end_time=None):
     """
     Generate access file if configured and not already existing.
-    
+
     Args:
         video_path (str): Path to the input video file
         source_directory (str): Source directory for the video
         video_id (str): Unique identifier for the video
-        command_config (object): Configuration object with tool settings
-        
+        check_cancelled (callable, optional): Function to check if operation was cancelled
+        signals (object, optional): Signal object for progress updates
+        color_bars_end_time (float, optional): End time of color bars in seconds, as
+            detected by qct-parse. When provided, the access copy is trimmed to start
+            after the bars.
+
     Returns:
         str or None: Path to the created access file, or None
     """
     config_mgr = ConfigManager()
     checks_config = config_mgr.get_config('checks', ChecksConfig)
-    
+
     # Check if access file should be generated
     if not checks_config.outputs.access_file:
         return None
@@ -105,7 +120,11 @@ def process_access_file(video_path, source_directory, video_id, check_cancelled=
             return None
 
         # Generate access file
-        make_access_file(video_path, access_output_path, check_cancelled=check_cancelled, signals=signals)
+        make_access_file(
+            video_path, access_output_path,
+            check_cancelled=check_cancelled, signals=signals,
+            start_time=color_bars_end_time
+        )
         if signals:
             signals.step_completed.emit("Generate Access File")
         return access_output_path

--- a/src/AV_Spex/checks/make_access.py
+++ b/src/AV_Spex/checks/make_access.py
@@ -18,12 +18,15 @@ def get_duration(video_path):
     return duration
 
 
-def make_access_file(video_path, output_path, check_cancelled=None, signals=None, start_time=None):
+def make_access_file(video_path, output_path, check_cancelled=None, signals=None, start_time=None, crop_area=None):
     """Create access file using ffmpeg.
 
     If start_time (seconds) is provided and > 0, the input is seeked past that
     point so head content (e.g. color bars detected by qct-parse) is excluded
     from the access copy.
+
+    If crop_area (x, y, w, h) is provided, the active picture area is cropped
+    out of the access copy. Width/height are forced even for yuv420p.
     """
 
     logger.debug(f'Running ffmpeg on {os.path.basename(video_path)} to create access copy {os.path.basename(output_path)}\n')
@@ -37,10 +40,22 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
         logger.info(f'Trimming first {start_time:.2f}s from access copy (color bars detected by qct-parse)\n')
         ffmpeg_command.extend(['-ss', f'{start_time:.3f}'])
 
+    vf_filters = []
+    if crop_area:
+        x, y, w, h = (int(v) for v in crop_area)
+        # yuv420p requires even dimensions
+        if w % 2:
+            w -= 1
+        if h % 2:
+            h -= 1
+        vf_filters.append(f'crop={w}:{h}:{x}:{y}')
+        logger.info(f'Cropping access copy to active area {w}x{h} at offset ({x},{y})\n')
+    vf_filters.extend(['yadif=1', 'format=yuv420p'])
+
     ffmpeg_command.extend([
         '-i', video_path,
         '-movflags', 'faststart', '-map', '0:v:0', '-map', '0:a?', '-c:v', 'libx264',
-        '-vf', 'yadif=1,format=yuv420p', '-crf', '18', '-preset', 'fast', '-maxrate', '1000k', '-bufsize', '1835k',
+        '-vf', ','.join(vf_filters), '-crf', '18', '-preset', 'fast', '-maxrate', '1000k', '-bufsize', '1835k',
         '-c:a', 'aac', '-strict', '-2', '-b:a', '192k', '-f', 'mp4', output_path
     ])
 
@@ -79,7 +94,7 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
     print("\n")
 
 
-def process_access_file(video_path, source_directory, video_id, check_cancelled=None, signals=None, color_bars_end_time=None):
+def process_access_file(video_path, source_directory, video_id, check_cancelled=None, signals=None, color_bars_end_time=None, crop_area=None):
     """
     Generate access file if configured and not already existing.
 
@@ -92,6 +107,9 @@ def process_access_file(video_path, source_directory, video_id, check_cancelled=
         color_bars_end_time (float, optional): End time of color bars in seconds, as
             detected by qct-parse. When provided, the access copy is trimmed to start
             after the bars.
+        crop_area (tuple, optional): (x, y, w, h) active picture area from sophisticated
+            border detection (BRNG-refined when available). When provided, borders are
+            cropped off the access copy.
 
     Returns:
         str or None: Path to the created access file, or None
@@ -123,7 +141,8 @@ def process_access_file(video_path, source_directory, video_id, check_cancelled=
         make_access_file(
             video_path, access_output_path,
             check_cancelled=check_cancelled, signals=signals,
-            start_time=color_bars_end_time
+            start_time=color_bars_end_time,
+            crop_area=crop_area
         )
         if signals:
             signals.step_completed.emit("Generate Access File")

--- a/src/AV_Spex/checks/make_access.py
+++ b/src/AV_Spex/checks/make_access.py
@@ -18,6 +18,27 @@ def get_duration(video_path):
     return duration
 
 
+def get_video_dimensions(video_path):
+    """Return (width, height) of the first video stream, or (None, None) on failure."""
+    command = [
+        'ffprobe',
+        '-v', 'error',
+        '-select_streams', 'v:0',
+        '-show_entries', 'stream=width,height',
+        '-of', 'csv=p=0:s=x',
+        video_path
+    ]
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out = result.stdout.decode().strip()
+        if not out or 'x' not in out:
+            return None, None
+        w_str, h_str = out.split('x', 1)
+        return int(w_str), int(h_str)
+    except (ValueError, subprocess.SubprocessError):
+        return None, None
+
+
 def make_access_file(video_path, output_path, check_cancelled=None, signals=None, start_time=None, crop_area=None):
     """Create access file using ffmpeg.
 
@@ -25,8 +46,11 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
     point so head content (e.g. color bars detected by qct-parse) is excluded
     from the access copy.
 
-    If crop_area (x, y, w, h) is provided, the active picture area is cropped
-    out of the access copy. Width/height are forced even for yuv420p.
+    Output dimensions follow the source standard: NTSC (720x486 input) → 720x480,
+    PAL (720x576 input) → 720x576. With no crop_area, the NTSC input is trimmed
+    by 3 lines top and bottom; PAL is left at its native height. With a crop_area
+    from frame analysis, the active region is cropped and then scaled to the
+    standard output size for that source.
     """
 
     logger.debug(f'Running ffmpeg on {os.path.basename(video_path)} to create access copy {os.path.basename(output_path)}\n')
@@ -40,6 +64,20 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
         logger.info(f'Trimming first {start_time:.2f}s from access copy (color bars detected by qct-parse)\n')
         ffmpeg_command.extend(['-ss', f'{start_time:.3f}'])
 
+    in_w, in_h = get_video_dimensions(video_path)
+
+    # Pick the target output size based on the source standard.
+    if in_h == 576:
+        out_w, out_h = 720, 576  # PAL
+    elif in_h == 486:
+        out_w, out_h = 720, 480  # NTSC
+    else:
+        # Unknown standard — fall back to the input size so we don't distort.
+        out_w, out_h = in_w, in_h
+        logger.warning(
+            f'Unexpected input height {in_h}; access copy will use input dimensions {in_w}x{in_h}\n'
+        )
+
     vf_filters = []
     if crop_area:
         x, y, w, h = (int(v) for v in crop_area)
@@ -49,7 +87,19 @@ def make_access_file(video_path, output_path, check_cancelled=None, signals=None
         if h % 2:
             h -= 1
         vf_filters.append(f'crop={w}:{h}:{x}:{y}')
-        logger.info(f'Cropping access copy to active area {w}x{h} at offset ({x},{y})\n')
+        if out_w and out_h:
+            vf_filters.append(f'scale={out_w}:{out_h}')
+            logger.info(
+                f'Cropping access copy to active area {w}x{h} at offset ({x},{y}), '
+                f'then scaling to {out_w}x{out_h}\n'
+            )
+        else:
+            logger.info(f'Cropping access copy to active area {w}x{h} at offset ({x},{y})\n')
+    elif in_h == 486:
+        # NTSC 720x486: drop top 3 and bottom 3 lines to produce 720x480
+        vf_filters.append('crop=720:480:0:3')
+        logger.info('Cropping top/bottom 3 lines of access copy to produce 720x480 output\n')
+    # PAL (576) and unknown sources pass through with no default crop.
     vf_filters.extend(['yadif=1', 'format=yuv420p'])
 
     ffmpeg_command.extend([

--- a/src/AV_Spex/processing/processing_mgmt.py
+++ b/src/AV_Spex/processing/processing_mgmt.py
@@ -233,24 +233,12 @@ class ProcessingManager:
         
         # Process QCTools output and capture color bars detection
         qctools_results = process_qctools_output(
-            video_path, source_directory, destination_directory, video_id, 
+            video_path, source_directory, destination_directory, video_id,
             report_directory=report_directory,
             check_cancelled=self.check_cancelled, signals=self.signals
         )
         color_bars_end_time = qctools_results.get('color_bars_end_time') if qctools_results else None
-        
-        if self.signals:
-            self.signals.output_progress.emit("Creating access file...")
-        if self.check_cancelled():
-            return None
-        
-        # Generate access file
-        processing_results['access_file'] = process_access_file(
-            video_path, source_directory, video_id, 
-            check_cancelled=self.check_cancelled,
-            signals=self.signals
-        )
-        
+
         # Check if frame analysis is enabled
         frame_config = self.checks_config.outputs.frame_analysis
         if any([
@@ -265,21 +253,34 @@ class ProcessingManager:
                 self.signals.output_progress.emit("Performing enhanced frame analysis...")
                 # Reset the detail progress bar before frame analysis begins
                 self.signals.frame_analysis_progress.emit(0)
-            
+
             # Run the new unified frame analysis, passing color bars info from qct-parse
             frame_analysis_results = self.process_frame_analysis(
                 video_path, source_directory, destination_directory, video_id,
                 color_bars_end_time=color_bars_end_time
             )
-            
+
             processing_results['frame_analysis'] = frame_analysis_results
-        
+
         if self.signals:
             self.signals.frame_analysis_progress.emit(0)
+            self.signals.output_progress.emit("Creating access file...")
+        if self.check_cancelled():
+            return None
+
+        # Generate access file (runs after qct-parse and frame analysis so it can
+        # take advantage of details learned during those steps)
+        processing_results['access_file'] = process_access_file(
+            video_path, source_directory, video_id,
+            check_cancelled=self.check_cancelled,
+            signals=self.signals
+        )
+
+        if self.signals:
             self.signals.output_progress.emit("Preparing report...")
         if self.check_cancelled():
             return None
-        
+
         # Generate final HTML report
         processing_results['html_report'] = generate_final_report(
             video_id, source_directory, report_directory, destination_directory,

--- a/src/AV_Spex/processing/processing_mgmt.py
+++ b/src/AV_Spex/processing/processing_mgmt.py
@@ -268,14 +268,31 @@ class ProcessingManager:
         if self.check_cancelled():
             return None
 
+        # Pull a crop region from sophisticated border detection (BRNG-refined when
+        # available). Skip simple detection — the user has opted not to crop in
+        # that case because the bordered area is a fixed fallback, not a real
+        # measurement. detection_method is 'sophisticated_refined' after BRNG
+        # refinement, plain 'sophisticated' otherwise.
+        access_crop_area = None
+        frame_results = processing_results.get('frame_analysis')
+        if frame_results:
+            border = frame_results.get('border_results')
+            if border:
+                method = border.get('detection_method') or ''
+                if method.startswith('sophisticated') and border.get('active_area'):
+                    access_crop_area = border['active_area']
+
         # Generate access file (runs after qct-parse and frame analysis so it can
         # take advantage of details learned during those steps). When qct-parse
         # detected color bars, color_bars_end_time trims them off the access copy.
+        # When sophisticated border detection produced an active area, crop_area
+        # removes the borders.
         processing_results['access_file'] = process_access_file(
             video_path, source_directory, video_id,
             check_cancelled=self.check_cancelled,
             signals=self.signals,
-            color_bars_end_time=color_bars_end_time
+            color_bars_end_time=color_bars_end_time,
+            crop_area=access_crop_area
         )
 
         if self.signals:

--- a/src/AV_Spex/processing/processing_mgmt.py
+++ b/src/AV_Spex/processing/processing_mgmt.py
@@ -269,11 +269,13 @@ class ProcessingManager:
             return None
 
         # Generate access file (runs after qct-parse and frame analysis so it can
-        # take advantage of details learned during those steps)
+        # take advantage of details learned during those steps). When qct-parse
+        # detected color bars, color_bars_end_time trims them off the access copy.
         processing_results['access_file'] = process_access_file(
             video_path, source_directory, video_id,
             check_cancelled=self.check_cancelled,
-            signals=self.signals
+            signals=self.signals,
+            color_bars_end_time=color_bars_end_time
         )
 
         if self.signals:


### PR DESCRIPTION
Use information from qct-parse and frame analysis during creation of access file:
- exclude color bars
- crop any detected head switching or VBI
- Scale to 720x480