### PR TITLE
Fix/border detect crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "0.9.8.6"
+version = "0.9.8.7"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/processing/worker_thread.py
+++ b/src/AV_Spex/processing/worker_thread.py
@@ -17,6 +17,10 @@ class ProcessingWorker(QThread):
     
     def __init__(self, source_directories, signals, dry_run=False, parent=None):
         super().__init__(parent)
+        # macOS Accelerate's dgetrf_parallel (reached via np.linalg.inv from
+        # matplotlib tight_layout/savefig) overflows Qt's default ~512KB
+        # secondary-thread stack and crashes with SIGBUS.
+        self.setStackSize(16 * 1024 * 1024)
         self.source_directories = source_directories
         self.signals = signals
         self.dry_run = dry_run


### PR DESCRIPTION
Processing Worker thread in the Qt gui needed more than the default allotted memory to run on larger files