### PR TITLE
Use github.repository instead of hardcoded old repo name in brew work…

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -129,7 +129,7 @@ jobs:
           brew install --build-bottle --verbose JPC-AV/AV-Spex/av-spex
           
           echo "Creating bottle..."
-          brew bottle --verbose --json --root-url=https://github.com/JPC-AV/video_qc_jpc_av/releases/download/${{ steps.version.outputs.tag_name }} JPC-AV/AV-Spex/av-spex
+          brew bottle --verbose --json --root-url=https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag_name }} JPC-AV/AV-Spex/av-spex
           
           # Create Homebrew-compatible copies
           for bottle_file in av-spex--*.bottle.tar.gz; do

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -144,8 +144,8 @@ jobs:
           include Language::Python::Virtualenv
         
           desc "Python project for NMAAHC media conservation lab"
-          homepage "https://github.com/JPC-AV/video_qc_jpc_av"
-          url "https://github.com/JPC-AV/video_qc_jpc_av/archive/refs/tags/${{ steps.get_version.outputs.tag_name }}.tar.gz"
+          homepage "https://github.com/${{ github.repository }}"
+          url "https://github.com/${{ github.repository }}/archive/refs/tags/${{ steps.get_version.outputs.tag_name }}.tar.gz"
           sha256 "${{ steps.get_sha.outputs.sha256 }}"
           license "GPL-3.0-only"
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "1.1.8"
+version = "1.1.9"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
…flows

The formula url/homepage and bottle root-url hardcoded the pre-rename repo name (video_qc_jpc_av). After the rename to AV-Spex, the workflow hashed the archive served under the canonical name while the formula pointed at the old name, and the rename itself changed the archive bytes — breaking source installs of v1.1.3 (#294). Using github.repository keeps the generated formula consistent with whatever the repo is currently named.