### PR TITLE
Fix/clams strream hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ namespaces = false
 "AV_Spex" = [
     "config/*.json",
     "config/mediaconch_policies/*.xml",
+    "config/clams_bars/*.png",
+    "config/clams_bars/LICENSE",
     "logo_image_files/*.png"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/checks/embed_fixity.py
+++ b/src/AV_Spex/checks/embed_fixity.py
@@ -216,8 +216,8 @@ def make_stream_hash(video_path, check_cancelled=None, signals=None):
 
 
 def extract_tags(video_path):
-    command = f"mkvextract tags {video_path}"
-    result = subprocess.run(command, capture_output=True, text=True, shell=True)
+    command = ["mkvextract", "tags", str(video_path)]
+    result = subprocess.run(command, capture_output=True, text=True)
     # mkvextract returns non-zero on non-Matroska input (and may still write
     # non-XML text to stdout). Treat that as "no tags" so downstream parsing
     # is skipped gracefully instead of raising a ParseError.


### PR DESCRIPTION
Fixes for: 
- homebrew and pip install builds that excluded CLAMS bars png and license. 
- Bad path quoting in mkvextract shell call