### PR TITLE
Feature/eval smpte bars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AV_Spex"
-version = "1.3.2"
+version = "1.3.3"
 description = "A Python project written for NMAAHC media conservation lab"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/AV_Spex/av_spex_the_file.py
+++ b/src/AV_Spex/av_spex_the_file.py
@@ -110,6 +110,7 @@ class ParsedArguments:
     enable_audio_analysis: Optional[str]
     enable_chroma_phase_detection: Optional[str]
     enable_tone_leak_detection: Optional[str]
+    evaluate_bars_reference: Optional[str]
     access_trim_color_bars: Optional[str]
     access_crop_borders: Optional[str]
     access_crop_to_480: Optional[str]
@@ -218,6 +219,8 @@ The scripts will confirm that the digital files conform to predetermined specifi
                            help='Enable/disable chroma phase error detection in qct-parse (detects tape tracking artifacts where chroma collapses toward cyan/magenta). Auto-enables qct_parse.run_tool.')
     qct_group.add_argument('--enable-tone-leak-detection', choices=['on', 'off'],
                            help='Enable/disable reference-tone leak detection (1 kHz calibration tone crosstalk heard as a faint whine/squeak in quiet passages). Analyzes decoded audio directly. Auto-enables qct_parse.run_tool.')
+    qct_group.add_argument('--evaluate-bars-reference', choices=['detected', 'smpte'],
+                           help="What Evaluate Color Bars grades content against: 'detected' (default) uses this file's own detected bars, falling back to standard SMPTE values when none are found; 'smpte' always grades against standard SMPTE values. Only takes effect when evaluateBars is on.")
 
     # Frame analysis sub-steps + tuning
     frame_group = parser.add_argument_group("Frame analysis")
@@ -326,6 +329,7 @@ The scripts will confirm that the digital files conform to predetermined specifi
         enable_audio_analysis=getattr(args, 'enable_audio_analysis', None),
         enable_chroma_phase_detection=getattr(args, 'enable_chroma_phase_detection', None),
         enable_tone_leak_detection=getattr(args, 'enable_tone_leak_detection', None),
+        evaluate_bars_reference=getattr(args, 'evaluate_bars_reference', None),
         access_trim_color_bars=getattr(args, 'access_trim_color_bars', None),
         access_crop_borders=getattr(args, 'access_crop_borders', None),
         access_crop_to_480=getattr(args, 'access_crop_to_480', None),
@@ -596,6 +600,8 @@ def run_cli_mode(args):
         tools_updates.setdefault('qct_parse', {})['detect_chroma_phase_errors'] = (args.enable_chroma_phase_detection == 'on')
     if args.enable_tone_leak_detection:
         tools_updates.setdefault('qct_parse', {})['detect_tone_leak'] = (args.enable_tone_leak_detection == 'on')
+    if args.evaluate_bars_reference:
+        tools_updates.setdefault('qct_parse', {})['evaluateBarsReference'] = args.evaluate_bars_reference
     if args.enable_clams_detection:
         tools_updates.setdefault('clams_detection', {})['run_tool'] = (args.enable_clams_detection == 'on')
 
@@ -626,6 +632,14 @@ def run_cli_mode(args):
         logger.warning(
             "access_file_exclude_flagged_audio is on but qct-parse audio analysis is off; "
             "the option will have no effect until --enable-audio-analysis on is set."
+        )
+
+    # Soft warning (no forcing): the bars-evaluation reference only matters
+    # when Evaluate Color Bars is running.
+    if args.evaluate_bars_reference and not final_checks.tools.qct_parse.evaluateBars:
+        logger.warning(
+            "--evaluate-bars-reference was set but qct_parse.evaluateBars is off; "
+            "the reference will have no effect until Evaluate Color Bars is enabled."
         )
 
     # Input video extension. Persist the selection, then auto-disable MKV-only

--- a/src/AV_Spex/checks/qct_parse.py
+++ b/src/AV_Spex/checks/qct_parse.py
@@ -3961,8 +3961,17 @@ def run_qctparse(video_path, qctools_output_path, report_directory, check_cancel
     ######## Iterate Through the XML for Bars Evaluation ########
     if qct_parse['evaluateBars']:
         bars_fallback = False
+        smpte_selected = False
+        # "detected" (default): grade content against this file's own detected
+        # bars, falling back to SMPTE values when none are found. "smpte":
+        # always grade against standard SMPTE values, regardless of detection.
+        evaluate_reference = qct_parse.get('evaluateBarsReference', 'detected')
 
-        if qct_parse['barsDetection'] and durationStart == "" and durationEnd == "":
+        if evaluate_reference == 'smpte':
+            logger.info("Evaluate Color Bars: grading against standard SMPTE color bars values (user-selected reference).\n")
+            maxBarsDict = asdict(spex_config.qct_parse_values.smpte_color_bars)
+            smpte_selected = True
+        elif qct_parse['barsDetection'] and durationStart == "" and durationEnd == "":
             logger.warning(f"No color bars found - falling back to SMPTE color bars values from config.\n")
             maxBarsDict = asdict(spex_config.qct_parse_values.smpte_color_bars)
             bars_fallback = True
@@ -3977,10 +3986,13 @@ def run_qctparse(video_path, qctools_output_path, report_directory, check_cancel
             logger.debug(f"Starting qct-parse color bars evaluation on {baseName}\n")
             smpte_color_bars = asdict(spex_config.qct_parse_values.smpte_color_bars)
             colorbars_values_output = os.path.join(report_directory, "qct-parse_colorbars_values.csv")
-            
+
             if bars_fallback:
                 with open(colorbars_values_output, 'w') as f:
                     f.write("SMPTE_FALLBACK\n")
+            elif smpte_selected:
+                with open(colorbars_values_output, 'w') as f:
+                    f.write("SMPTE_SELECTED\n")
             else:
                 print_color_bar_values(baseName, smpte_color_bars, maxBarsDict, colorbars_values_output)
             

--- a/src/AV_Spex/checks/qct_parse.py
+++ b/src/AV_Spex/checks/qct_parse.py
@@ -3962,6 +3962,10 @@ def run_qctparse(video_path, qctools_output_path, report_directory, check_cancel
     if qct_parse['evaluateBars']:
         bars_fallback = False
         smpte_selected = False
+        # Detected bar values measured for the report graph in "smpte" mode
+        # (the evaluation itself still grades against SMPTE); None when no bars
+        # were detected.
+        smpte_detected_values = None
         # "detected" (default): grade content against this file's own detected
         # bars, falling back to SMPTE values when none are found. "smpte":
         # always grade against standard SMPTE values, regardless of detection.
@@ -3971,6 +3975,11 @@ def run_qctparse(video_path, qctools_output_path, report_directory, check_cancel
             logger.info("Evaluate Color Bars: grading against standard SMPTE color bars values (user-selected reference).\n")
             maxBarsDict = asdict(spex_config.qct_parse_values.smpte_color_bars)
             smpte_selected = True
+            # If bars were detected, measure them too so the report can still
+            # render the informational detected-vs-SMPTE graph. These values
+            # are graph-only; the evaluation grades against maxBarsDict (SMPTE).
+            if qct_parse['barsDetection'] and durationStart != "" and durationEnd != "":
+                smpte_detected_values = evalBars(startObj, pkt, durationStart, durationEnd, framesList, buffSize)
         elif qct_parse['barsDetection'] and durationStart == "" and durationEnd == "":
             logger.warning(f"No color bars found - falling back to SMPTE color bars values from config.\n")
             maxBarsDict = asdict(spex_config.qct_parse_values.smpte_color_bars)
@@ -3991,8 +4000,15 @@ def run_qctparse(video_path, qctools_output_path, report_directory, check_cancel
                 with open(colorbars_values_output, 'w') as f:
                     f.write("SMPTE_FALLBACK\n")
             elif smpte_selected:
-                with open(colorbars_values_output, 'w') as f:
-                    f.write("SMPTE_SELECTED\n")
+                if smpte_detected_values is not None:
+                    # Bars were detected: write the real detected-vs-SMPTE
+                    # comparison CSV so the report renders the graph. The
+                    # report reads evaluateBarsReference to also show the
+                    # "SMPTE selected" info box above it.
+                    print_color_bar_values(baseName, smpte_color_bars, smpte_detected_values, colorbars_values_output)
+                else:
+                    with open(colorbars_values_output, 'w') as f:
+                        f.write("SMPTE_SELECTED\n")
             else:
                 print_color_bar_values(baseName, smpte_color_bars, maxBarsDict, colorbars_values_output)
             

--- a/src/AV_Spex/config/checks_config.json
+++ b/src/AV_Spex/config/checks_config.json
@@ -72,6 +72,7 @@
       "barsDetection": true,
       "evaluateBars": true,
       "thumbExport": true,
+      "evaluateBarsReference": "detected",
       "audio_analysis": false,
       "detect_clamped_levels": false,
       "detect_chroma_phase_errors": false,

--- a/src/AV_Spex/gui/gui_complex_window.py
+++ b/src/AV_Spex/gui/gui_complex_window.py
@@ -1,6 +1,6 @@
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QCheckBox, QLineEdit,
-    QLabel, QComboBox, QStyle, QStyleOptionButton
+    QLabel, QComboBox, QStyle, QStyleOptionButton, QRadioButton, QButtonGroup
 )
 from PyQt6.QtCore import Qt
 
@@ -99,11 +99,14 @@ class ComplexWindow(QWidget, ThemeableMixin):
         pair.addWidget(desc)
         layout.addLayout(pair)
 
-    def _indent_row(self, widget):
-        """Return an HBox with the widget indented under its parent option."""
+    def _indent_row(self, widget, indent=None):
+        """Return an HBox with the widget indented under its parent option.
+
+        `indent` defaults to one level (self.INDENT); pass a larger value for
+        controls nested a further level down (e.g. self.INDENT * 2)."""
         row = QHBoxLayout()
         row.setSpacing(6)  # explicit: nested rows inherit _add_option's 0 spacing
-        row.addSpacing(self.INDENT)
+        row.addSpacing(self.INDENT if indent is None else indent)
         row.addWidget(widget)
         row.addStretch()
         return row
@@ -192,8 +195,32 @@ class ComplexWindow(QWidget, ThemeableMixin):
 
         self.evaluate_bars_cb = self._make_checkbox("Evaluate Color Bars")
         self._add_option(layout, self._indent_row(self.evaluate_bars_cb), self._desc_label(
-            "Compare content to color bars for validation",
+            "Compare video content against reference color bar values for validation",
             extra_indent=self.INDENT))
+
+        # Reference selection: what the evaluation grades content against.
+        # Nested a further level under Evaluate Color Bars.
+        self.bars_ref_label = QLabel("Compare against:")
+        self.bars_ref_label.setIndent(self.DESC_INDENT)
+        layout.addLayout(self._indent_row(self.bars_ref_label, self.INDENT * 2))
+
+        self.bars_ref_group = QButtonGroup(self)
+        self.bars_ref_detected_radio = QRadioButton("Bars detected in this video")
+        self.bars_ref_smpte_radio = QRadioButton("Standard SMPTE values")
+        self.bars_ref_group.addButton(self.bars_ref_detected_radio)
+        self.bars_ref_group.addButton(self.bars_ref_smpte_radio)
+        self.bars_ref_detected_radio.setChecked(True)
+
+        self._add_option(layout, self._indent_row(self.bars_ref_detected_radio, self.INDENT * 2),
+            self._desc_label(
+                "Uses levels measured from this file's own color bars. If no "
+                "bars are found, standard SMPTE values are used as a fallback.",
+                extra_indent=self.INDENT * 2))
+        self._add_option(layout, self._indent_row(self.bars_ref_smpte_radio, self.INDENT * 2),
+            self._desc_label(
+                "Always uses standard SMPTE color bar values, ignoring any "
+                "bars in the video.",
+                extra_indent=self.INDENT * 2))
 
         self.thumb_export_cb = self._make_checkbox("Export Thumbnails")
         self._add_option(layout, self._indent_row(self.thumb_export_cb), self._desc_label(
@@ -435,7 +462,8 @@ class ComplexWindow(QWidget, ThemeableMixin):
             self.enable_signalstats_cb.setEnabled(True)
 
     def _apply_bars_dependencies(self):
-        """Evaluate Bars and Export Thumbnails depend on Detect Color Bars."""
+        """Evaluate Bars and Export Thumbnails depend on Detect Color Bars;
+        the bars-reference radios depend on Evaluate Color Bars."""
         bars_on = self.bars_detection_cb.isChecked()
         for cb in (self.evaluate_bars_cb, self.thumb_export_cb):
             if not bars_on:
@@ -443,6 +471,11 @@ class ComplexWindow(QWidget, ThemeableMixin):
                 cb.setChecked(False)
                 cb.blockSignals(False)
             cb.setEnabled(bars_on)
+
+        evaluate_on = bars_on and self.evaluate_bars_cb.isChecked()
+        for w in (self.bars_ref_label, self.bars_ref_detected_radio,
+                  self.bars_ref_smpte_radio):
+            w.setEnabled(evaluate_on)
 
     def on_theme_changed(self, palette):
         """Handle theme changes for ComplexWindow"""
@@ -481,6 +514,10 @@ class ComplexWindow(QWidget, ThemeableMixin):
                    self.detect_clamped_levels_cb, self.detect_chroma_phase_errors_cb,
                    self.detect_tone_leak_cb):
             cb.stateChanged.connect(self.on_qct_parse_flag_changed)
+
+        # Bars-reference radios: the detected radio's toggled fires exactly
+        # once per user change (exclusive pair), so one connection is enough.
+        self.bars_ref_detected_radio.toggled.connect(self.on_qct_parse_flag_changed)
 
         # CLAMS detection — single toggle runs both bars and tone detectors.
         # Numeric tuning is JSON-only.
@@ -580,6 +617,9 @@ class ComplexWindow(QWidget, ThemeableMixin):
         self.bars_detection_cb.setChecked(run_tool and qct.barsDetection)
         self.evaluate_bars_cb.setChecked(run_tool and qct.evaluateBars)
         self.thumb_export_cb.setChecked(run_tool and qct.thumbExport)
+        bars_ref = getattr(qct, 'evaluateBarsReference', 'detected')
+        self.bars_ref_smpte_radio.setChecked(bars_ref == 'smpte')
+        self.bars_ref_detected_radio.setChecked(bars_ref != 'smpte')
         self.audio_analysis_cb.setChecked(run_tool and getattr(qct, 'audio_analysis', False))
         self.detect_clamped_levels_cb.setChecked(run_tool and getattr(qct, 'detect_clamped_levels', False))
         self.detect_chroma_phase_errors_cb.setChecked(run_tool and getattr(qct, 'detect_chroma_phase_errors', False))
@@ -671,12 +711,17 @@ class ComplexWindow(QWidget, ThemeableMixin):
             'barsDetection': self.bars_detection_cb.isChecked(),
             'evaluateBars': self.evaluate_bars_cb.isChecked(),
             'thumbExport': self.thumb_export_cb.isChecked(),
+            'evaluateBarsReference': self._bars_reference_value(),
             'audio_analysis': self.audio_analysis_cb.isChecked(),
             'detect_clamped_levels': self.detect_clamped_levels_cb.isChecked(),
             'detect_chroma_phase_errors': self.detect_chroma_phase_errors_cb.isChecked(),
             'detect_tone_leak': self.detect_tone_leak_cb.isChecked(),
         }}}
         config_mgr.update_config('checks', updates)
+
+    def _bars_reference_value(self):
+        """Current Evaluate Color Bars reference: 'smpte' or 'detected'."""
+        return 'smpte' if self.bars_ref_smpte_radio.isChecked() else 'detected'
 
     def on_frame_analysis_mode_changed(self, index):
         """Handle border detection mode changes"""

--- a/src/AV_Spex/gui/gui_custom_profiles.py
+++ b/src/AV_Spex/gui/gui_custom_profiles.py
@@ -1,8 +1,8 @@
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, 
+    QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel,
     QScrollArea, QPushButton, QComboBox, QCheckBox, QGroupBox,
     QMessageBox, QDialog, QTextEdit, QGridLayout, QListWidget,
-    QFileDialog
+    QFileDialog, QRadioButton, QButtonGroup
 )
 from PyQt6.QtCore import Qt
 
@@ -384,9 +384,37 @@ class CustomProfileDialog(QDialog, ThemeableMixin):
         # Evaluate Bars
         self.evaluate_bars_check = QCheckBox("Evaluate Color Bars")
         self.evaluate_bars_check.setStyleSheet("font-weight: bold;")
-        evaluate_bars_desc = QLabel("Compare content to color bars for validation")
+        evaluate_bars_desc = QLabel("Compare video content against reference color bar values for validation")
         evaluate_bars_desc.setIndent(20)
-        
+
+        # Evaluate Bars reference: what the evaluation grades content against.
+        bars_ref_label = QLabel("Compare against:")
+        bars_ref_label.setIndent(40)
+        self.bars_ref_group = QButtonGroup(self)
+        self.bars_ref_detected_radio = QRadioButton("Bars detected in this video")
+        self.bars_ref_smpte_radio = QRadioButton("Standard SMPTE values")
+        self.bars_ref_group.addButton(self.bars_ref_detected_radio)
+        self.bars_ref_group.addButton(self.bars_ref_smpte_radio)
+        self.bars_ref_detected_radio.setChecked(True)
+        bars_ref_detected_row = QHBoxLayout()
+        bars_ref_detected_row.addSpacing(40)
+        bars_ref_detected_row.addWidget(self.bars_ref_detected_radio)
+        bars_ref_detected_row.addStretch()
+        bars_ref_detected_desc = QLabel(
+            "Uses levels measured from this file's own color bars. If no bars "
+            "are found, standard SMPTE values are used as a fallback.")
+        bars_ref_detected_desc.setIndent(60)
+        bars_ref_detected_desc.setWordWrap(True)
+        bars_ref_smpte_row = QHBoxLayout()
+        bars_ref_smpte_row.addSpacing(40)
+        bars_ref_smpte_row.addWidget(self.bars_ref_smpte_radio)
+        bars_ref_smpte_row.addStretch()
+        bars_ref_smpte_desc = QLabel(
+            "Always uses standard SMPTE color bar values, ignoring any bars "
+            "in the video.")
+        bars_ref_smpte_desc.setIndent(60)
+        bars_ref_smpte_desc.setWordWrap(True)
+
         # Thumb Export
         self.thumb_export_check = QCheckBox("Thumbnail Export")
         self.thumb_export_check.setStyleSheet("font-weight: bold;")
@@ -406,6 +434,11 @@ class CustomProfileDialog(QDialog, ThemeableMixin):
         qct_parse_layout.addWidget(bars_detection_desc)
         qct_parse_layout.addWidget(self.evaluate_bars_check)
         qct_parse_layout.addWidget(evaluate_bars_desc)
+        qct_parse_layout.addWidget(bars_ref_label)
+        qct_parse_layout.addLayout(bars_ref_detected_row)
+        qct_parse_layout.addWidget(bars_ref_detected_desc)
+        qct_parse_layout.addLayout(bars_ref_smpte_row)
+        qct_parse_layout.addWidget(bars_ref_smpte_desc)
         qct_parse_layout.addWidget(self.thumb_export_check)
         qct_parse_layout.addWidget(thumb_export_desc)
         qct_parse_layout.addWidget(self.audio_analysis_check)
@@ -785,6 +818,9 @@ class CustomProfileDialog(QDialog, ThemeableMixin):
             self.bars_detection_check.setChecked(qct_config.barsDetection)
             self.evaluate_bars_check.setChecked(qct_config.evaluateBars)
             self.thumb_export_check.setChecked(qct_config.thumbExport)
+            bars_ref = getattr(qct_config, 'evaluateBarsReference', 'detected')
+            self.bars_ref_smpte_radio.setChecked(bars_ref == 'smpte')
+            self.bars_ref_detected_radio.setChecked(bars_ref != 'smpte')
             self.audio_analysis_check.setChecked(getattr(qct_config, 'audio_analysis', False))
 
         except Exception as e:
@@ -885,8 +921,11 @@ class CustomProfileDialog(QDialog, ThemeableMixin):
         self.bars_detection_check.setChecked(qct_config.barsDetection)
         self.evaluate_bars_check.setChecked(qct_config.evaluateBars)
         self.thumb_export_check.setChecked(qct_config.thumbExport)
+        bars_ref = getattr(qct_config, 'evaluateBarsReference', 'detected')
+        self.bars_ref_smpte_radio.setChecked(bars_ref == 'smpte')
+        self.bars_ref_detected_radio.setChecked(bars_ref != 'smpte')
         self.audio_analysis_check.setChecked(getattr(qct_config, 'audio_analysis', False))
-    
+
     def get_profile_from_form(self):
         """Create a ChecksProfile from the form data."""
         # Validate required fields
@@ -964,6 +1003,7 @@ class CustomProfileDialog(QDialog, ThemeableMixin):
                 barsDetection=self.bars_detection_check.isChecked(),
                 evaluateBars=self.evaluate_bars_check.isChecked(),
                 thumbExport=self.thumb_export_check.isChecked(),
+                evaluateBarsReference=('smpte' if self.bars_ref_smpte_radio.isChecked() else 'detected'),
                 audio_analysis=self.audio_analysis_check.isChecked()
             )
         )

--- a/src/AV_Spex/utils/config_edit.py
+++ b/src/AV_Spex/utils/config_edit.py
@@ -1320,6 +1320,7 @@ profile_step1 = {
             "barsDetection": False,
             "evaluateBars": False,
             "thumbExport": False,
+            "evaluateBarsReference": "detected",
             "audio_analysis": False,
             "detect_clamped_levels": False
         },
@@ -1393,6 +1394,7 @@ profile_step2 = {
             "barsDetection": True,
             "evaluateBars": True,
             "thumbExport": True,
+            "evaluateBarsReference": "detected",
             "audio_analysis": True,
             "detect_clamped_levels": True,
             "detect_chroma_phase_errors": True
@@ -1468,6 +1470,7 @@ profile_allOff = {
             "barsDetection": False,
             "evaluateBars": False,
             "thumbExport": False,
+            "evaluateBarsReference": "detected",
             "audio_analysis": False,
             "detect_clamped_levels": False,
             "detect_chroma_phase_errors": False,
@@ -1547,6 +1550,7 @@ profile_vendor = {
             "barsDetection": False,
             "evaluateBars": False,
             "thumbExport": False,
+            "evaluateBarsReference": "detected",
             "audio_analysis": False,
             "detect_clamped_levels": False
         },

--- a/src/AV_Spex/utils/config_setup.py
+++ b/src/AV_Spex/utils/config_setup.py
@@ -332,6 +332,10 @@ class QCTParseToolConfig:
     barsDetection: bool
     evaluateBars: bool
     thumbExport: bool
+    # What Evaluate Bars measures content against: "detected" uses this
+    # file's own detected bars, falling back to standard SMPTE values if
+    # none are found; "smpte" always uses standard SMPTE values.
+    evaluateBarsReference: str = "detected"
     audio_analysis: bool = False
     detect_clamped_levels: bool = False
     detect_chroma_phase_errors: bool = False

--- a/src/AV_Spex/utils/generate_report.py
+++ b/src/AV_Spex/utils/generate_report.py
@@ -5622,6 +5622,13 @@ def write_html_report(video_id, report_directory, destination_directory, html_re
                     <p style="margin: 0; color: #856404;"><strong>No color bars detected.</strong> Evaluation was performed using standard SMPTE color bar values.</p>
                 </div>
                 """
+            elif first_line == "SMPTE_SELECTED":
+                smpte_fallback = True
+                colorbars_html = """
+                <div style="background-color: #fff3cd; padding: 15px; border: 1px solid #856404; margin: 10px 0; border-radius: 5px;">
+                    <p style="margin: 0; color: #856404;">Evaluation was performed against standard SMPTE color bar values (selected reference).</p>
+                </div>
+                """
             else:
                 colorbars_html = make_color_bars_graphs(video_id, qctools_colorbars_duration_output, colorbars_values_output, thumbs_dict)
         except Exception as e:

--- a/src/AV_Spex/utils/generate_report.py
+++ b/src/AV_Spex/utils/generate_report.py
@@ -5609,28 +5609,51 @@ def write_html_report(video_id, report_directory, destination_directory, html_re
     else:
         colorbars_eval_html = None
 
-    # Check if SMPTE fallback was used
-    smpte_fallback = False
+    # How the color-bars evaluation graded content, which drives the section
+    # headers and whether an info box accompanies the graph:
+    #   - "detected" reference, bars found -> detected-vs-SMPTE graph only
+    #   - "detected" reference, no bars    -> SMPTE fallback, info box only
+    #   - "smpte" reference, bars found    -> graph + "SMPTE selected" info box
+    #   - "smpte" reference, no bars       -> "SMPTE selected" info box only
+    # smpte_reference: SMPTE values were the evaluation reference (drives the
+    # "Values relative to ... thresholds" header). colorbars_box_only: the
+    # colorbars_html is just an info box with no graph (drives the graph
+    # section header).
+    smpte_selected_box = """
+                <div style="background-color: #fff3cd; padding: 15px; border: 1px solid #856404; margin: 10px 0; border-radius: 5px;">
+                    <p style="margin: 0; color: #856404;">Evaluation was performed against standard SMPTE color bar values (selected reference).</p>
+                </div>
+                """
+    smpte_reference = False
+    colorbars_box_only = False
     if colorbars_values_output:
         try:
             with open(colorbars_values_output, 'r') as f:
                 first_line = f.readline().strip()
             if first_line == "SMPTE_FALLBACK":
-                smpte_fallback = True
+                smpte_reference = True
+                colorbars_box_only = True
                 colorbars_html = """
                 <div style="background-color: #fff3cd; padding: 15px; border: 1px solid #856404; margin: 10px 0; border-radius: 5px;">
                     <p style="margin: 0; color: #856404;"><strong>No color bars detected.</strong> Evaluation was performed using standard SMPTE color bar values.</p>
                 </div>
                 """
             elif first_line == "SMPTE_SELECTED":
-                smpte_fallback = True
-                colorbars_html = """
-                <div style="background-color: #fff3cd; padding: 15px; border: 1px solid #856404; margin: 10px 0; border-radius: 5px;">
-                    <p style="margin: 0; color: #856404;">Evaluation was performed against standard SMPTE color bar values (selected reference).</p>
-                </div>
-                """
+                smpte_reference = True
+                colorbars_box_only = True
+                colorbars_html = smpte_selected_box
             else:
-                colorbars_html = make_color_bars_graphs(video_id, qctools_colorbars_duration_output, colorbars_values_output, thumbs_dict)
+                # Real detected-vs-SMPTE comparison CSV -> render the graph.
+                graph_html = make_color_bars_graphs(video_id, qctools_colorbars_duration_output, colorbars_values_output, thumbs_dict)
+                evaluate_reference = config_mgr.get_config('checks', ChecksConfig).tools.qct_parse.evaluateBarsReference
+                if evaluate_reference == 'smpte':
+                    # SMPTE was the evaluation reference but bars were detected:
+                    # show the informational graph with the "SMPTE selected" box
+                    # below it.
+                    smpte_reference = True
+                    colorbars_html = (graph_html or "") + smpte_selected_box
+                else:
+                    colorbars_html = graph_html
         except Exception as e:
             logger.error(f"Error reading colorbars values file: {e}")
             colorbars_html = None
@@ -6118,7 +6141,7 @@ def write_html_report(video_id, report_directory, destination_directory, html_re
     if colorbars_html or windowed_colorbars_html_list:
         html_template += '<div style="display: flex; flex-wrap: wrap; gap: 24px; align-items: flex-start;">'
         if colorbars_html:
-            if smpte_fallback:
+            if colorbars_box_only:
                 colorbars_header = "Color Bars Detection"
             else:
                 colorbars_header = f"SMPTE Colorbars vs {video_id} Colorbars"
@@ -6235,7 +6258,7 @@ def write_html_report(video_id, report_directory, destination_directory, html_re
             """
 
     if colorbars_eval_html:
-        if smpte_fallback:
+        if smpte_reference:
             eval_header = "Values relative to SMPTE colorbar's thresholds"
         else:
             eval_header = "Values relative to colorbar's thresholds"


### PR DESCRIPTION
Adding a radio button option to evaluate QCTools xml levels using either the input video's detected bars or standard smpte bars. Still requires detect bars so that bars can be excluded from the evaluation. 